### PR TITLE
Use localhost instead of 127.0.0.1 for SonarQube API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           go-version: '1.21'
       - run: test -z $(gofmt -l .)
-      - run: go build ./cmd/instant-sonar.go
+      - run: GOPROXY=direct go build ./cmd/instant-sonar.go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      GONOPROXY: github.com/docker/docker
+      GONOPROXY: github.com/docker
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GONOPROXY: github.com/docker/docker
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           go-version: '1.21'
       - run: test -z $(gofmt -l .)
-      - run: GOPROXY=direct go build ./cmd/instant-sonar.go
+      - run: go build ./cmd/instant-sonar.go

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
       GOOS: ${{ matrix.goos }}
       GOARCH: ${{ matrix.goarch }}
       GOARM: ${{ matrix.goarm }}
+      GONOPROXY: github.com/docker
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/cmd/instant-sonar.go
+++ b/cmd/instant-sonar.go
@@ -108,7 +108,7 @@ func main() {
 	out.Close()
 	log.Verboseln("SonarQube is operational")
 
-	sonarApi := sonar.NewApiClient("http://127.0.0.1:9000", opts.username, opts.password)
+	sonarApi := sonar.NewApiClient("http://localhost:9000", opts.username, opts.password)
 
 	log.Verboseln("Checking SonarQube API")
 	if err := sonarApi.Ping(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module instant-sonar
 go 1.21
 
 require (
-	github.com/docker/docker v24.0.5+incompatible
+	github.com/docker/docker v24.0.6+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/spf13/pflag v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v24.0.5+incompatible h1:WmgcE4fxyI6EEXxBRxsHnZXrO1pQ3smi0k/jho4HLeY=
-github.com/docker/docker v24.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.6+incompatible h1:hceabKCtUgDqPu+qm0NgsaXf28Ljf4/pWFL7xjWWDgE=
+github.com/docker/docker v24.0.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=


### PR DESCRIPTION
When connecting to the SonarQube container, `127.0.0.1` doesn't seem to work on Mac. Instead `localhost` should be used. Thanks @DannyvdSluijs for reporting!